### PR TITLE
#19-Upgrade 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 ***rest-request*** is inspired by Spring Webflux's `WebClient`, which similarly allows method-chaining methods to create HTTP Headers, Query Parameters, Form Data, Request Body, and more.
 ~~~java
-RestRequest<ResponseType> request = RestRequest.response(ResponseType.class)
+RestRequest<ResponseType> request = RestRequest.resp(ResponseType.class)
                                                .uri("http://www.api.com/resources")
                                                .post()
                                                .addHeader("X-Test-Header-Name", "XTestHeaderValue")
-                                               .addParameter("queryParamKey", "queryParamValue")
+                                               .addParam("queryParamKey", "queryParamValue")
                                                .body(requestBodyObject)
                                                .build();
 ResponsType response = restTemplate.exchange(request.getUri(),
@@ -28,16 +28,16 @@ There are four types of responses:
 - 4. Void type : `Class<Void>`
 ~~~java
 // 1. Preference : Map<String, Object>
-RestRequest.mapResponse()
+RestRequest.mapResp()
 
 // 2. T type : Class<T>
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
 
 // 3. Generic T type : ParameterizedTypeReference<T>
-RestRequest.response(new ParameterizedTypeReference<List<ResponseType>>(){})
+RestRequest.resp(new ParameterizedTypeReference<List<ResponseType>>(){})
 
 // 4. Void type : Class<Void>
-RestRequest.nonResponse()
+RestRequest.nonResp()
 ~~~
 
 ### **2. Request URI**
@@ -45,18 +45,18 @@ The URI to request supports paramters of the `java.net.URI` or `String` type.
 ~~~java
 // java.net.URI type
 URI uri = URI.create("http://www.api.com/resources");
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
 
 // String type
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri("http://www.api.com/resources")
 ~~~
 
 ### **3. HTTP Method**
 HTTP Method can be specified by a method name with an intuitive name. The methods that supports it are GET / POST / PUT / PATCH / DELETE. Here, the POST / PUT / PATCH method allows you to set the Request Body in the near time.
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get() / .post() / .put() / .patch() / .delete()
 ~~~
@@ -67,7 +67,7 @@ Afterwards, you can set HTTP Headers, Query Parameters, Form Datas, and Request 
 - **HTTP Header**  
 HTTP Header can be added as an **`addHeader()`, `accept()`, `contentType()`, `authorization()`, `basicAuth()`** and **`bearerToken()`** methods.
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get()
            .addHeader("headerName", "headerValue")
@@ -78,31 +78,31 @@ RestRequest.response(ResponseType.class)
            .bearerToken("tokenValue")
 ~~~
 - **Form Parameter**  
-You can add Form Parameters with the **`addParameter()`, `putAllParamters()`** methods.  
+You can add Form Parameters with the **`addParam()`, `setParams()`** methods.  
 If you previously specified `get()` / `delete()`, Query Parameter is generated, and if `post()` / `put()` / `patch()` is specified, Form Data is generated.  
 If both Request Body and Form Parameter are set, they are generated as Query Parameters, even if `post()` / `put()` / `patch()` is specified.
 ~~~java
 // Generate a Query Parameter
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get()
-           .addParameter("paramKey", "paramValue")  // Add Query Parameter : key-value
-           .putAllParameters(multiValueMap)         // Add Query Parameter : MultiValueMap<String, Object>
-           .putAllParameters(map)                   // Add Query Parameter : Map<String, Object>
-           .putAllParameters(object)                // Add Query Parameter : Object
+           .addParam("paramKey", "paramValue")  // Add Query Parameter : key-value
+           .setParams(multiValueMap)            // Add Query Parameter : MultiValueMap<String, Object>
+           .setParams(map)                      // Add Query Parameter : Map<String, Object>
+           .setParams(object)                   // Add Query Parameter : Object
 
 // Generate Form Datas
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .post()
-           .addParameter("paramKey", "paramValue")
+           .addParam("paramKey", "paramValue")
 ~~~
 - **Request Body**  
 You can set it as a **`body()`** method. (You can call the `body()` method only when specifying `post()` / `put()` / `patch()` methods.)
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .put()
-           .addParameter("queryParamKey", "queryParamValue")  // Generate Query Parameter
+           .addParam("queryParamKey", "queryParamValue")  // Generate Query Parameter
            .body(requestBodyObject)
 ~~~
 
@@ -116,7 +116,7 @@ Finally, call **`build()`** method to generate `RestRequest`.
 - `ParameterizedTypeReference<T>`
 ~~~java
 // Class<T> when specifying
-RestRequest<ResponseType> request = RestRequest.response(ResponseType.class)
+RestRequest<ResponseType> request = RestRequest.resp(ResponseType.class)
                                                .uri(uri)
                                                .get()
                                                .build();
@@ -126,7 +126,7 @@ ResponseType response = restTemplate.exchange(request.getUri(),
                                               request.getResponseType());
 
 // ParameterizedTypeReference<T> when specifying
-RestRequest<List<ResponseType>> request = RestRequest.response(new ParameterizedTypeReference<List<ResponseType>>(){})
+RestRequest<List<ResponseType>> request = RestRequest.resp(new ParameterizedTypeReference<List<ResponseType>>(){})
                                                      .uri(uri)
                                                      .get()
                                                      .build();
@@ -166,19 +166,36 @@ public class WebService {
     private RestClientAdpater restClient;
     
     public ResponseEntity<Resource> getSome(ResourceDto dto) {
-        return restClient.execute(RestRequest.response(Resource.class)
-                                             .uri("http://www.api.com/resources")
-                                             .get()
-                                             .putAllParameters(dto)
-                                             .build());
+        return restClient.send(RestRequest.resp(Resource.class)
+                                          .uri("http://www.api.com/resources")
+                                          .get()
+                                          .setParams(dto)
+                                          .build());
     }
     
     public Optional<Resource> postSome(Resource resource) {
-        return restClient.executeForObject(RestRequest.response(Resource.class)
-                                                      .uri("http://www.api.com/resources")
-                                                      .post()
-                                                      .body(resource)
-                                                      .build());
+        return restClient.sendForBody(RestRequest.resp(Resource.class)
+                                                 .uri("http://www.api.com/resources")
+                                                 .post()
+                                                 .body(resource)
+                                                 .build());
+    }
+
+    public CompletableFuture<ResponseEntity<Resource>> getSomeAsync(ResourceDto dto) {
+        return restClient.sendAsync(RestRequest.resp(Resource.class)
+                                               .uri("http://www.api.com/resources")
+                                               .get()
+                                               .setParams(dto)
+                                               .build());
+    }
+
+    public Compublic CompletableFuture<ResponseEntity<Resource>> getSomeAsync(ResourceDto dto, Executor executor) {
+        return restClient.sendAsync(RestRequest.resp(Resource.class)
+                                               .uri("http://www.api.com/resources")
+                                               .get()
+                                               .setParams(dto)
+                                               .build(),
+                                    executor);
     }
 }
 ~~~
@@ -193,10 +210,10 @@ public class WebService {
 <dependency>
     <groupId>io.github.libedi</groupId>
     <artifactId>rest-request</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
 </dependency>
 ~~~
 - ### **Gradle**
 ~~~groovy
-implementation 'io.github.libedi:rest-request:1.1.2'
+implementation 'io.github.libedi:rest-request:2.0.0'
 ~~~

--- a/README_kr.MD
+++ b/README_kr.MD
@@ -3,11 +3,11 @@
 
 ***rest-request***는 Spring Webflux의 `WebClient`에서 영감을 받아, 이와 유사하게 메소드 체이닝 방식으로 HTTP Header, Query Parameter, Form Data, Request Body 등을 생성할 수 있습니다.
 ~~~java
-RestRequest<ResponseType> request = RestRequest.response(ResponseType.class)
+RestRequest<ResponseType> request = RestRequest.resp(ResponseType.class)
                                                .uri("http://www.api.com/resources")
                                                .post()
                                                .addHeader("X-Test-Header-Name", "XTestHeaderValue")
-                                               .addParameter("queryParamKey", "queryParamValue")
+                                               .addParam("queryParamKey", "queryParamValue")
                                                .body(requestBodyObject)
                                                .build();
 ResponsType response = restTemplate.exchange(request.getUri(),
@@ -28,16 +28,16 @@ ResponsType response = restTemplate.exchange(request.getUri(),
 - 4. Void타입 : `Class<Void>`
 ~~~java
 // 1. 기본설정 : Map<String, Object>
-RestRequest.mapResponse()
+RestRequest.mapResp()
 
 // 2. T타입 설정 : Class<T>
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
 
 // 3. T타입 제네릭 설정 : ParameterizedTypeReference<T>
-RestRequest.response(new ParameterizedTypeReference<List<ResponseType>>(){})
+RestRequest.resp(new ParameterizedTypeReference<List<ResponseType>>(){})
 
 // 4. Void타입 설정 : Class<Void>
-RestRequest.nonResponse()
+RestRequest.nonResp()
 ~~~
 
 ### **2. 요청 URI**
@@ -45,18 +45,18 @@ RestRequest.nonResponse()
 ~~~java
 // java.net.URI 타입
 URI uri = URI.create("http://www.api.com/resources");
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
 
 // java.lang.String 타입
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri("http://www.api.com/resources")
 ~~~
 
 ### **3. HTTP Method**
 HTTP Method는 직관적인 이름의 메소드명으로 지정할 수 있습니다. 지원하는 메소드는 GET / POST / PUT / PATCH / DELETE 입니다. 여기서 POST / PUT / PATCH 방식은 이후에 Request Body를 설정가능하게 합니다.
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get() / .post() / .put() / .patch() / .delete()
 ~~~
@@ -67,7 +67,7 @@ RestRequest.response(ResponseType.class)
 - **HTTP Header**  
 HTTP Header는 **`addHeader()`, `accept()`, `contentType()`, `authorization()`, `basicAuth()`, `bearerToken()`** 메소드로 추가할 수 있습니다.
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get()
            .addHeader("headerName", "headerValue")
@@ -78,31 +78,31 @@ RestRequest.response(ResponseType.class)
            .bearerToken("tokenValue")
 ~~~
 - **Form Parameter**  
-**`addParameter()`, `putAllParameters()`** 메소드로 Form Parameter를 추가할 수 있습니다.  
+**`addParam()`, `setParams()`** 메소드로 Form Parameter를 추가할 수 있습니다.  
 이전에 `get()` / `delete()`를 지정했다면, Query Parameter가 생성되고, `post()` / `put()` / `patch()`를 지정했다면, Form Data가 생성됩니다.  
 만약, `post()` / `put()` / `patch()`를 지정했더라도, Request Body와 Form Parameter 둘 다 설정되었다면, Query Parameter로 생성됩니다.
 ~~~java
 // Query Parameter 생성
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .get()
-           .addParameter("paramKey", "paramValue")  // Query Parameter 추가 : key-value 방식
-           .putAllParameters(multiValueMap)         // Query Parameter 추가 : MultiValueMap<String, Object>
-           .putAllParameters(map)                   // Query Parameter 추가 : Map<String, Object>
-           .putAllParameters(object)                // Query Parameter 추가 : Object
+           .addParam("paramKey", "paramValue")  // Query Parameter 추가 : key-value 방식
+           .setParams(multiValueMap)            // Query Parameter 추가 : MultiValueMap<String, Object>
+           .setParams(map)                      // Query Parameter 추가 : Map<String, Object>
+           .setParams(object)                   // Query Parameter 추가 : Object
 
 // Form Data 생성
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .uri(uri)
            .post()
-           .addParameter("paramKey", "paramValue")
+           .addParam("paramKey", "paramValue")
 ~~~
 - **Request Body**  
 **`body()`** 메소드로 설정할 수 있습니다. (`post()` / `put()` / `patch()` 지정시에만 `body()` 메소드를 호출할 수 있습니다.)
 ~~~java
-RestRequest.response(ResponseType.class)
+RestRequest.resp(ResponseType.class)
            .put()
-           .addParameter("queryParamKey", "queryParamValue")  // Query Parameter로 생성
+           .addParam("queryParamKey", "queryParamValue")  // Query Parameter로 생성
            .body(requestBodyObject)
 ~~~
 
@@ -116,7 +116,7 @@ RestRequest.response(ResponseType.class)
 - `ParameterizedTypeReference<T>`
 ~~~java
 // Class<T> 지정시
-RestRequest<ResponseType> request = RestRequest.response(ResponseType.class)
+RestRequest<ResponseType> request = RestRequest.resp(ResponseType.class)
                                                .uri(uri)
                                                .get()
                                                .build();
@@ -126,7 +126,7 @@ ResponseType response = restTemplate.exchange(request.getUri(),
                                               request.getResponseType());
 
 // ParameterizedTypeReference<T> 지정시
-RestRequest<List<ResponseType>> request = RestRequest.response(new ParameterizedTypeReference<List<ResponseType>>(){})
+RestRequest<List<ResponseType>> request = RestRequest.resp(new ParameterizedTypeReference<List<ResponseType>>(){})
                                                      .uri(uri)
                                                      .get()
                                                      .build();
@@ -166,19 +166,36 @@ public class WebService {
     private RestClientAdpater restClient;
     
     public ResponseEntity<Resource> getSome(ResourceDto dto) {
-        return restClient.execute(RestRequest.response(Resource.class)
-                                             .uri("http://www.api.com/resources")
-                                             .get()
-                                             .putAllParameters(dto)
-                                             .build());
+        return restClient.send(RestRequest.resp(Resource.class)
+                                          .uri("http://www.api.com/resources")
+                                          .get()
+                                          .setParams(dto)
+                                          .build());
     }
     
     public Optional<Resource> postSome(Resource resource) {
-        return restClient.executeForObject(RestRequest.response(Resource.class)
-                                                      .uri("http://www.api.com/resources")
-                                                      .post()
-                                                      .body(resource)
-                                                      .build());
+        return restClient.sendForBody(RestRequest.resp(Resource.class)
+                                                 .uri("http://www.api.com/resources")
+                                                 .post()
+                                                 .body(resource)
+                                                 .build());
+    }
+
+    public CompletableFuture<ResponseEntity<Resource>> getSomeAsync(ResourceDto dto) {
+        return restClient.sendAsync(RestRequest.resp(Resource.class)
+                                               .uri("http://www.api.com/resources")
+                                               .get()
+                                               .setParams(dto)
+                                               .build());
+    }
+
+    public Compublic CompletableFuture<ResponseEntity<Resource>> getSomeAsync(ResourceDto dto, Executor executor) {
+        return restClient.sendAsync(RestRequest.resp(Resource.class)
+                                               .uri("http://www.api.com/resources")
+                                               .get()
+                                               .setParams(dto)
+                                               .build(),
+                                    executor);
     }
 }
 ~~~
@@ -193,10 +210,10 @@ public class WebService {
 <dependency>
     <groupId>io.github.libedi</groupId>
     <artifactId>rest-request</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
 </dependency>
 ~~~
 - ### **Gradle**
 ~~~groovy
-implementation 'io.github.libedi:rest-request:1.1.2'
+implementation 'io.github.libedi:rest-request:2.0.0'
 ~~~

--- a/rest-request/pom.xml
+++ b/rest-request/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.libedi</groupId>
   <artifactId>rest-request</artifactId>
-  <version>1.1.2</version>
+  <version>2.0.0</version>
   <name>rest-request</name>
   <description>HTTP Request Generator for RestTemplate</description>
   <url>https://github.com/libedi/rest-request</url>

--- a/rest-request/src/main/java/io/github/libedi/restrequest/DefaultRestClientAdapter.java
+++ b/rest-request/src/main/java/io/github/libedi/restrequest/DefaultRestClientAdapter.java
@@ -35,16 +35,16 @@ public class DefaultRestClientAdapter implements RestClientAdapter {
 
 
 	@Override
-	public <T> ResponseEntity<T> execute(final RestRequest<T> request) {
-        if (request == null) {
+    public <T> ResponseEntity<T> send(final RestRequest<T> restRequest) {
+        if (restRequest == null) {
             throw new IllegalArgumentException("RestRequest must not be null.");
         }
-		if (request.getTypeReference() == null) {
-			return restTemplate.exchange(request.getUri(), request.getMethod(), request.getHttpEntity(),
-					request.getResponseType());
+        if (restRequest.getTypeReference() == null) {
+            return restTemplate.exchange(restRequest.getUri(), restRequest.getMethod(), restRequest.getHttpEntity(),
+                    restRequest.getResponseType());
 		}
-		return restTemplate.exchange(request.getUri(), request.getMethod(), request.getHttpEntity(),
-				request.getTypeReference());
+        return restTemplate.exchange(restRequest.getUri(), restRequest.getMethod(), restRequest.getHttpEntity(),
+                restRequest.getTypeReference());
 	}
 
 }

--- a/rest-request/src/main/java/io/github/libedi/restrequest/DefaultRestRequestFormSpec.java
+++ b/rest-request/src/main/java/io/github/libedi/restrequest/DefaultRestRequestFormSpec.java
@@ -45,7 +45,9 @@ public class DefaultRestRequestFormSpec<T, S extends RestRequestFormSpec<T, S>>
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public S addParameter(final String key, final Object value) {
+    public S addParam(final String key, final Object value) {
+        Objects.requireNonNull(key, () -> "Key must not be null.");
+
 		if (parameter == null) {
 			parameter = new LinkedMultiValueMap<>();
 		}
@@ -53,9 +55,18 @@ public class DefaultRestRequestFormSpec<T, S extends RestRequestFormSpec<T, S>>
 		return (S) this;
 	}
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public S addParam(final String key, final Object... values) {
+        for (final Object value : values) {
+            addParam(key, value);
+        }
+        return (S) this;
+    }
+
 	@SuppressWarnings("unchecked")
 	@Override
-	public S putAllParameters(final MultiValueMap<String, Object> multiValueMap) {
+    public S setParams(final MultiValueMap<String, Object> multiValueMap) {
 		Objects.requireNonNull(multiValueMap, () -> "Parameter must not be null.");
 
 		if (parameter == null) {
@@ -68,18 +79,18 @@ public class DefaultRestRequestFormSpec<T, S extends RestRequestFormSpec<T, S>>
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public S putAllParameters(final Map<String, Object> map) {
+    public S setParams(final Map<String, Object> map) {
 		Objects.requireNonNull(map, () -> "Parameter must not be null.");
 
 		for (final Entry<String, Object> entry : map.entrySet()) {
-			addParameter(entry.getKey(), entry.getValue());
+            addParam(entry.getKey(), entry.getValue());
 		}
 		return (S) this;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public S putAllParameters(final Object object) {
+    public S setParams(final Object object) {
 		Objects.requireNonNull(object, () -> "Parameter must not be null.");
 		Assert.isTrue((object instanceof Collection) == false, "Parameter must not be Collection.");
 
@@ -96,11 +107,11 @@ public class DefaultRestRequestFormSpec<T, S extends RestRequestFormSpec<T, S>>
         final Object value = field.get(object);
 
         if (value instanceof Collection) {
-            ((Collection<?>) value).forEach(el -> addParameter(name, el));
+            ((Collection<?>) value).forEach(el -> addParam(name, el));
         } else if (value != null && value.getClass().isArray()) {
-            Arrays.stream((Object[]) value).forEach(el -> addParameter(name, el));
+            Arrays.stream((Object[]) value).forEach(el -> addParam(name, el));
         } else {
-            addParameter(name, value);
+            addParam(name, value);
         }
     }
 

--- a/rest-request/src/main/java/io/github/libedi/restrequest/RestClientAdapter.java
+++ b/rest-request/src/main/java/io/github/libedi/restrequest/RestClientAdapter.java
@@ -1,6 +1,8 @@
 package io.github.libedi.restrequest;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import org.springframework.http.ResponseEntity;
 
@@ -13,22 +15,46 @@ import org.springframework.http.ResponseEntity;
 public interface RestClientAdapter {
 
 	/**
-     * RestRequest의 요청 정보로 요청 실행
+     * RestRequest의 요청 정보로 요청 전송
      * 
      * @param <T>
      * @param restRequest 생성한 RestRequest
      * @return the response as entity
      */
-    <T> ResponseEntity<T> execute(final RestRequest<T> restRequest);
+    <T> ResponseEntity<T> send(final RestRequest<T> restRequest);
 
 	/**
-     * RestRequest의 요청 정보로 요청 실행
+     * RestRequest의 요청 정보로 요청 전송
      * 
      * @param <T>
      * @param restRequest 생성한 RestRequest
      * @return the converted object
      */
-    default <T> Optional<T> executeForObject(final RestRequest<T> restRequest) {
-        return Optional.ofNullable(execute(restRequest).getBody());
+    default <T> Optional<T> sendForBody(final RestRequest<T> restRequest) {
+        return Optional.ofNullable(send(restRequest).getBody());
 	}
+
+    /**
+     * RestRequest의 요청 정보로 비동기 요청 전송
+     * 
+     * @param <T>
+     * @param restRequest 생성한 RestRequest
+     * @return the new CompletableFuture with ResponseEntity as return value
+     */
+    default <T> CompletableFuture<ResponseEntity<T>> sendAsync(final RestRequest<T> restRequest) {
+        return CompletableFuture.supplyAsync(() -> send(restRequest));
+    }
+
+    /**
+     * RestRequest의 요청 정보로 비동기 요청 전송
+     * 
+     * @param <T>
+     * @param restRequest 생성한 RestRequest
+     * @param executor    the executor to use for asynchronous execution
+     * @return the new CompletableFuture with ResponseEntity as return value
+     */
+    default <T> CompletableFuture<ResponseEntity<T>> sendAsync(final RestRequest<T> restRequest,
+            final Executor executor) {
+        return CompletableFuture.supplyAsync(() -> send(restRequest), executor);
+    }
 }

--- a/rest-request/src/main/java/io/github/libedi/restrequest/RestRequest.java
+++ b/rest-request/src/main/java/io/github/libedi/restrequest/RestRequest.java
@@ -42,8 +42,8 @@ public class RestRequest<T> implements Serializable {
 	 * 
 	 * @return
 	 */
-	public static DefaultRestRequestUriSpec<Map<String, Object>> mapResponse() {
-		return response(new ParameterizedTypeReference<Map<String, Object>>() {});
+	public static DefaultRestRequestUriSpec<Map<String, Object>> mapResp() {
+		return resp(new ParameterizedTypeReference<Map<String, Object>>() {});
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class RestRequest<T> implements Serializable {
 	 * @param responseType
 	 * @return
 	 */
-	public static <T> DefaultRestRequestUriSpec<T> response(final Class<T> responseType) {
+    public static <T> DefaultRestRequestUriSpec<T> resp(final Class<T> responseType) {
 		return new DefaultRestRequestUriSpec<>(responseType);
 	}
 
@@ -64,7 +64,7 @@ public class RestRequest<T> implements Serializable {
 	 * @param typeReference
 	 * @return
 	 */
-	public static <T> DefaultRestRequestUriSpec<T> response(final ParameterizedTypeReference<T> typeReference) {
+    public static <T> DefaultRestRequestUriSpec<T> resp(final ParameterizedTypeReference<T> typeReference) {
 		return new DefaultRestRequestUriSpec<>(typeReference);
 	}
 	
@@ -73,7 +73,7 @@ public class RestRequest<T> implements Serializable {
 	 * 
 	 * @return
 	 */
-	public static DefaultRestRequestUriSpec<Void> nonResponse() {
+    public static DefaultRestRequestUriSpec<Void> nonResp() {
 		return new DefaultRestRequestUriSpec<>(Void.class);
 	}
 

--- a/rest-request/src/main/java/io/github/libedi/restrequest/RestRequestSpec.java
+++ b/rest-request/src/main/java/io/github/libedi/restrequest/RestRequestSpec.java
@@ -276,35 +276,45 @@ public interface RestRequestSpec<T> {
 		 * @return
 		 * @throws NullPointerException key가 null인 경우
 		 */
-		S addParameter(String key, Object value);
+        S addParam(String key, Object value);
+
+        /**
+         * 파라미터 추가
+         * 
+         * @param key    파라미터 key
+         * @param values 파라미터 values
+         * @return
+         * @throws NullPointerException key가 null인 경우
+         */
+        S addParam(final String key, final Object... values);
 
 		/**
-		 * 파라미터 일괄 추가
-		 * 
-		 * @param multiValueMap
-		 * @return
-		 * @throws NullPointerException multiValueMap 파라미터가 null인 경우
-		 */
-		S putAllParameters(MultiValueMap<String, Object> multiValueMap);
+         * 파라미터 일괄 설정
+         * 
+         * @param multiValueMap
+         * @return
+         * @throws NullPointerException multiValueMap 파라미터가 null인 경우
+         */
+        S setParams(MultiValueMap<String, Object> multiValueMap);
 
 		/**
-		 * 파라미터 일괄 추가
-		 * 
-		 * @param map
-		 * @return
-		 * @throws NullPointerException map 파라미터가 null인 경우
-		 */
-		S putAllParameters(Map<String, Object> map);
+         * 파라미터 일괄 설정
+         * 
+         * @param map
+         * @return
+         * @throws NullPointerException map 파라미터가 null인 경우
+         */
+        S setParams(Map<String, Object> map);
 
 		/**
-		 * 파라미터 일괄 추가
-		 * 
-		 * @param object
-		 * @return
-		 * @throws NullPointerException     object 파라미터가 null인 경우
-		 * @throws IllegalArgumentException object 파라미터가 Collection인 경우
-		 */
-		S putAllParameters(Object object);
+         * 파라미터 일괄 설정
+         * 
+         * @param object
+         * @return
+         * @throws NullPointerException     object 파라미터가 null인 경우
+         * @throws IllegalArgumentException object 파라미터가 Collection인 경우
+         */
+        S setParams(Object object);
 	}
 
 	/**

--- a/rest-request/src/test/java/io/github/libedi/restrequest/test/RestRequestTest.java
+++ b/rest-request/src/test/java/io/github/libedi/restrequest/test/RestRequestTest.java
@@ -56,14 +56,14 @@ public class RestRequestTest {
 				.build().toUri();
 
 		// when
-		RestRequest<String> actual = RestRequest.response(responseType)
+        RestRequest<String> actual = RestRequest.resp(responseType)
 				.uri(uri)
 				.get()
 				.addHeader(customHeaderName, customHeaderValue)
 				.accept(accept)
 				.contentType(contentType)
                 .basicAuth(basicUsername, basicPassword)
-				.addParameter(paramKey, paramValue)
+                .addParam(paramKey, paramValue)
 				.build();
 
 		// then
@@ -106,14 +106,14 @@ public class RestRequestTest {
 				.build().toUri();
 
 		// when
-		RestRequest<List<String>> actual = RestRequest.response(typeReference)
+        RestRequest<List<String>> actual = RestRequest.resp(typeReference)
 				.uri(uri)
 				.post()
 				.addHeader(customHeaderName, customHeaderValue)
 				.accept(accept)
 				.contentType(contentType)
                 .bearerToken(bearerToken)
-				.addParameter(paramKey, paramValue)
+                .addParam(paramKey, paramValue)
 				.body(body)
 				.build();
 		


### PR DESCRIPTION
1. Simplify method names
    - `RestRequest.response()` to `RestRequest.resp()`
    - `RestRequestFormSpec.addParameter()` to `RestRequestFormSpec.addParam()`
    - `RestRequestFormSpec.putAllParameters()` to `RestRequestFormSpec.setParams()`
    - `RestClientAdapter.execute()` to `RestClientAdapter.send()`
    - `RestClientAdapter.executeForObject()` to `RestClientAdapter.sendForBody()`
2. Support asynchronous communication
    - Add asynchronous communication method with `CompletableFuture` as return value
3. Upgrade version
    - to 2.0.0